### PR TITLE
fix: some clang preprocessor errors

### DIFF
--- a/Framework3D/include/Nodes/make_standard_type.hpp
+++ b/Framework3D/include/Nodes/make_standard_type.hpp
@@ -3,13 +3,13 @@
 // For all the types that have a 'simple' builder. (No min, max, default value)
 #define DECLARE_SOCKET_TYPE(NAME)                                      \
     class NAME##Builder;                                               \
-    class NAME## : public SocketDeclaration {                          \
+    class NAME : public SocketDeclaration {                          \
        public:                                                         \
-        NAME##()                                                       \
+        NAME()                                                       \
         {                                                              \
             type = SocketType::NAME;                                   \
         }                                                              \
         NodeSocket* build(NodeTree* ntree, Node* node) const override; \
         using Builder = NAME##Builder;                                 \
     };                                                                 \
-    class NAME##Builder : public SocketDeclarationBuilder<NAME##> { };
+    class NAME##Builder : public SocketDeclarationBuilder<NAME> { };

--- a/Framework3D/include/Nodes/socket_types/basic_socket_types.hpp
+++ b/Framework3D/include/Nodes/socket_types/basic_socket_types.hpp
@@ -2,6 +2,7 @@
 
 #include "USTC_CG.h"
 #include "Nodes/pin.hpp"
+#include "float.h"
 
 USTC_CG_NAMESPACE_OPEN_SCOPE
 namespace decl {

--- a/Framework3D/source/nodes/intern/node_registry.cpp
+++ b/Framework3D/source/nodes/intern/node_registry.cpp
@@ -142,12 +142,12 @@ MakeType(Int, int, 1, Buffer);
 MakeType(Int, pxr::GfVec2i, 2, Buffer);
 MakeType(Int, pxr::GfVec3i, 3, Buffer);
 MakeType(Int, pxr::GfVec4i, 4, Buffer);
-MakeType(Float, pxr::GfVec2f, 2);
-MakeType(Float, pxr::GfVec3f, 3);
-MakeType(Float, pxr::GfVec4f, 4);
-MakeType(Int, pxr::GfVec2i, 2);
-MakeType(Int, pxr::GfVec3i, 3);
-MakeType(Int, pxr::GfVec4i, 4);
+MakeType(Float, pxr::GfVec2f, 2, );
+MakeType(Float, pxr::GfVec3f, 3, );
+MakeType(Float, pxr::GfVec4f, 4, );
+MakeType(Int, pxr::GfVec2i, 2, );
+MakeType(Int, pxr::GfVec3i, 3, );
+MakeType(Int, pxr::GfVec4i, 4, );
 #undef MakeTypeBuffer
 
 static SocketTypeInfo* make_socket_type_Int()


### PR DESCRIPTION
adding float.h to for FLT_MAX definitions.

These issues are produced on macOS with clang, error log before fix: https://gist.github.com/tiankaima/bbf4c312059ae27e107dd69ea6958126
NOTE: still other issues left to be resolved, see: https://gist.github.com/tiankaima/b196b4d02b51361e84ff9c786f82437c
